### PR TITLE
Add ruby

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,16 @@ _exactly_. At that point all remaining bugs will be declared
 features, and the output from TeX will remain the same
 for all eternity.
 
+## Ruby
+### by Yukihiro Matsumoto
+
+Ruby also likes the looks of SemVer. However they also wanted to
+add their [own flavor to the game](https://www.ruby-lang.org/en/news/2013/12/21/ruby-version-policy-changes-with-2-1-0/).
+Why should only MAJOR be allowed to release breaking changes? MINOR
+should get their slice of that cake as well. Also minor versions are like
+presents, so they are released every Christmas. Major versions on the other
+hand are only reserved for really special events (more special than Christmas).
+
 # Realization
 
 What ever happens, not everyone will understand your intentions,

--- a/index.html
+++ b/index.html
@@ -73,6 +73,14 @@ Stanford University and set the version number unto π
 <em>exactly</em>. At that point all remaining bugs will be declared
 features, and the output from TeX will remain the same
 for all eternity.</p>
+<h2 id="ruby">Ruby</h2>
+<h3 id="by-yukihiro-matsumoto">by Yukihiro Matsumoto</h3>
+<p>Ruby also likes the looks of SemVer. However they also wanted to
+add their <a href="https://www.ruby-lang.org/en/news/2013/12/21/ruby-version-policy-changes-with-2-1-0/">own flavor to the game</a>.
+Why should only MAJOR be allowed to release breaking changes? MINOR
+should get their slice of that cake as well. Also minor versions are like
+presents, so they are released every Christmas. Major versions on the other
+hand are only reserved for really special events (more special than Christmas).</p>
 <h1 id="realization">Realization</h1>
 <p>What ever happens, not everyone will understand your intentions,
 possibly your genius will not be recognized within your lifetime.


### PR DESCRIPTION
The Ruby version schema is pretty great. Breaking changes are allowed in minor, and they are only released on Christmas :christmas_tree: . I added a small text about this.

```
Version Schema
MAJOR: increased when incompatible change which can’t be released in MINOR
Reserved for special events
MINOR: increased every christmas, may be API incompatible
TEENY: security or bug fix which maintains API compatibility
May be increased more than 10 (such as 2.1.11), and will be released every 2-3 months.
PATCH: number of commits since last MINOR release (will be reset at 0 when releasing MINOR)
```

Source: https://www.ruby-lang.org/en/news/2013/12/21/ruby-version-policy-changes-with-2-1-0/
